### PR TITLE
Reduce the number of reads generated

### DIFF
--- a/yeast/big1.par
+++ b/yeast/big1.par
@@ -14,3 +14,6 @@ REF_FILE_NAME	chrI-100.gtf
 FASTA		true
 ERR_FILE	76
 READ_LENGTH	76
+
+# Make fewer reads
+READ_NUMBER  100000

--- a/yeast/big2.par
+++ b/yeast/big2.par
@@ -14,3 +14,6 @@ REF_FILE_NAME	chrI-100.gtf
 FASTA		true
 ERR_FILE	76
 READ_LENGTH	76
+
+# Make fewer reads
+READ_NUMBER  100000

--- a/yeast/small1.par
+++ b/yeast/small1.par
@@ -14,3 +14,6 @@ REF_FILE_NAME	chrI-100-20.gtf
 FASTA		true
 ERR_FILE	76
 READ_LENGTH	76
+
+# Make fewer reads
+READ_NUMBER  20000

--- a/yeast/small2.par
+++ b/yeast/small2.par
@@ -14,3 +14,6 @@ REF_FILE_NAME	chrI-100-20.gtf
 FASTA		true
 ERR_FILE	76
 READ_LENGTH	76
+
+# Make fewer reads
+READ_NUMBER  20000


### PR DESCRIPTION
Reduce the number of reads generated, to get a handle on memory usage. flux-simulator default is 5,000,000 reads, reduced to 100,000 for big[12].par, 20,000 for small[12].par.